### PR TITLE
Document dir and file features added in 1.27

### DIFF
--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -345,6 +345,10 @@ These files not:
 
 =back
 
+By default, C<ok_manifest> will look for the file C<MANIFEST> in the current working directory (which is how tests are traditionally run). If you wish to specify a different directory, you may pass the C<file> or C<dir> parameters, for example:
+
+  ok_manifest({dir => '/path/to/my/dist/'});
+
 =head1 EXCLUDING FILES
 
 Beside C<filter> and C<exclude> there is another way to exclude files:


### PR DESCRIPTION
Hi! I'm participating in the CPAN pull request challenge described here:

http://neilb.org/2014/11/29/pr-challenge-2015.html

I was assigned your Test::CheckManifest module and I couldn't find any outstanding issues or obvious problems. However, I did notice that the file/dir feature added in 1.27 isn't documented, so that's my pull request. :)

Cheers,

Doug