### PR TITLE
Ensure tests run in series

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6,6 +6,7 @@ t/00_load.t
 t/01_selftest.t
 t/xt/02_issue1.t
 't/file with whitespaces.txt'
+t/testrules.yml
 
 t/extra/02_test_in_subdirectory.t
 

--- a/dist.ini
+++ b/dist.ini
@@ -32,3 +32,6 @@ File::Basename = 0
 File::Find = 0
 Cwd = 0
 Carp = 0
+
+[Prereqs / TestRequires]
+CPAN::Meta::YAML = 0

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -1,0 +1,4 @@
+seq:
+    - t/*.t
+    - extra/*.t
+    - xt/*.t


### PR DESCRIPTION
Hi, I'm submitting this pull request because Test::CheckManifest was allocated to me as my April assignment in the CPAN Pull Request challenge.

I looked at the issues. Although I wasn't able to replicate the parallel test failure - in issue #4 - I have been able to make use of the TAP::Harness rules support (see "rulesfiles" under https://metacpan.org/pod/TAP::Harness#new ) to ensure that the tests run sequentially. 

(Parallel tests won't work because files are created and deleted in the main test, which could potentially break the other tests' manifest checks.)

I've added CPAN::Meta::YAML to the test prereqs, since the rulesfiles mechanism in TAP::Harness requires this to be available.

I hope this patch is useful.