### PR TITLE
used File::Spec to make and check absolute path

### DIFF
--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -76,7 +76,9 @@ sub _check_excludes {
     my @excluded;
 
     for my $excluded_path ( @{ $hashref->{exclude} } ) {
-        my $path = Cwd::realpath( $home . $excluded_path );
+        my $path = File::Spec->catdir($home, $excluded_path);
+		$path = File::Spec->rel2abs( $path )
+				unless File::Spec->file_name_is_absolute( $path );  
         next if !$path || !-e $path;
 
         push @excluded, $path;

--- a/t/03_find_home.t
+++ b/t/03_find_home.t
@@ -13,12 +13,26 @@ use Test::CheckManifest;
 # create a directory and a file 
 my $sub = Test::CheckManifest->can('_find_home');
 
-my $dir  = Cwd::realpath( dirname __FILE__ );
-$dir     =~ s{.t\z}{};
+my $dir = File::Spec->curdir();
+$dir = File::Spec->rel2abs($dir);
+
 my $file = File::Spec->catfile( $dir, 'MANIFEST' );
 
-is $sub->( {} ), $dir, 'tmp_path => $0';
-is $sub->( { file => $file } ), $dir, 'file';
-is $sub->( { dir  => $dir } ), $dir, 'dir';
+my @dirs_one = File::Spec->splitdir( $dir );
+my @dirs_two = File::Spec->splitdir( $sub->( {} ) );
+is_deeply  	\@dirs_one, \@dirs_two, 'tmp_path => $0';
+
+
+my ($vol,$dirs,$file_one) = File::Spec->splitpath($file);
+
+my @dirs_three = File::Spec->splitdir( $sub->( {file => $file} ) );
+my @dirs_four = File::Spec->splitdir( 
+										File::Spec->catdir($vol,$dirs)
+);
+is_deeply  	\@dirs_three, \@dirs_four, 'file';
+
+my @dirs_five = File::Spec->splitdir( $sub->( { dir  => $dir } )  );
+my @dirs_six = File::Spec->splitdir( $dir );
+is_deeply  	\@dirs_three, \@dirs_four, 'dir';
 
 done_testing();


### PR DESCRIPTION
the previous method failed for me because of missing path separator:
<pre>
io@COMP:C>perl -I ./lib ./t/01_selftest.t
1..10
ok 1 - expected: Manifest not ok
C:/Users/io/Test-CheckManifest/blib: No such file or directory at lib/Test/CheckManifest.pm line 79.
# Looks like your test exited with 2 just after 1.

io@COMP:C>perl -I ./lib ./t/04_check_excludes.t
C:/Users/io/Test-CheckManifesttesting: No such file or directory at lib/Test/CheckManifest.pm line 79.
</pre>

After change 04_check_excludes is ok and 01_selftest.t has other problems

