### PR TITLE
used keys %missing_files instead of buckets used

### DIFF
--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -234,7 +234,7 @@ sub _check_manifest {
         $success = $bool == $test_bool;
     }
 
-    $test->diag($diag) if %missing_files     >= 1 and $test_bool == 1 and $VERBOSE;
+    $test->diag($diag) if keys %missing_files     >= 1 and $test_bool == 1 and $VERBOSE;
     $test->diag($plus) if scalar @files_plus >= 1 and $test_bool == 1 and $VERBOSE;
     $test->diag($dup)  if scalar @dup_files  >= 1 and $test_bool == 1 and $VERBOSE;
 


### PR DESCRIPTION
you had a typo in code:
<pre>
./t/01_selftest.t ..
1..10
Argument "18/32" isn't numeric in numeric ge (>=) at C:\Users\io\test-checkmani1.38\lib/Test/CheckManifest.pm line 237.
</pre>