### PR TITLE
Removed regex warnings on windows box as reported by CPANTESTERS.

### DIFF
--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -296,7 +296,7 @@ sub _is_excluded{
     if ( $files_in_skip ) {
         (my $local_file = $file) =~ s{\Q$home\E}{};
         for my $rx ( @{$files_in_skip} ) {
-            my $regex = qr/$rx/;
+            my $regex = qr/\Q$rx\E/;
             return 1 if $local_file =~ $regex;
         }
     }


### PR DESCRIPTION
Hi @reneeb 

Please review the PR.
I noticed the following warnings on windows platform as reported by CPANTESTERS.

https://www.cpantesters.org/cpan/report/9abe5ffc-6bf7-1014-8b43-15b730923c42
https://www.cpantesters.org/cpan/report/b77056de-6bf3-1014-8232-e907002427db

       Unrecognized escape \T passed through in regex; marked by <-- HERE in m/C:\strawberry182\cpan\build\T <-- HERE est-CheckManifest-1.39-0\t\05_is_excluded.t/ at C:\strawberry182\cpan\build\Test-CheckManifest-1.39-0\blib\lib/Test/CheckManifest.pm line 299.
       Unrecognized escape \T passed through in regex; marked by <-- HERE in m/C:\strawberry182\cpan\build\T <-- HERE est-CheckManifest-1.39-0\t\05_is_excluded.t.bak/ at C:\strawberry182\cpan\build\Test-CheckManifest-1.39-0\blib\lib/Test/CheckManifest.pm line 299.
       Unrecognized escape \T passed through in regex; marked by <-- HERE in m/C:\strawberry182\cpan\build\T <-- HERE est-CheckManifest-1.39-0\t\05_is_excluded.t.bak/ at C:\strawberry182\cpan\build\Test-CheckManifest-1.39-0\blib\lib/Test/CheckManifest.pm line 299.
       Unrecognized escape \T passed through in regex; marked by <-- HERE in m/C:\strawberry182\cpan\build\T <-- HERE est-CheckManifest-1.39-0\t\05_is_excluded.t/ at C:\strawberry182\cpan\build\Test-CheckManifest-1.39-0\blib\lib/Test/CheckManifest.pm line 299.

Many Thanks.
Best Regards,
Mohammad S Anwar