### PR TITLE
Declare version as string

### DIFF
--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -13,7 +13,7 @@ use Test::Builder;
 use File::Find;
 use Scalar::Util qw(blessed);
 
-our $VERSION = 1.41;
+our $VERSION = '1.41';
 our $VERBOSE = 1;
 our $HOME;
 our $test_bool = 1;


### PR DESCRIPTION
Versions are strings and should always be declared as such. This prevents losing digits with releases such as '1.40' which can cause problems for vendor packagers. See http://blogs.perl.org/users/grinnz/2018/04/a-guide-to-versions-in-perl.html for more details.