### PR TITLE
Files are compared with leading slash agains the regexes in MANIFEST.SKIP

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/reneeb/Test-CheckManifest.svg?branch=master)](https://travis-ci.org/reneeb/Test-CheckManifest)
-[![Kwalitee status](http://cpants.cpanauthors.org/dist/Test-CheckManifest.png)](http://cpants.charsbar.org/dist/overview/Test-CheckManifest)
+[![Kwalitee status](https://cpants.cpanauthors.org/dist/Test-CheckManifest.png)](https://cpants.cpanauthors.org/dist/Test-CheckManifest)
 [![GitHub issues](https://img.shields.io/github/issues/reneeb/Test-CheckManifest.svg)](https://github.com/reneeb/Test-CheckManifest/issues)
 
 # NAME
@@ -81,7 +81,7 @@ Beside `filter` and `exclude` there is another way to exclude files:
 # REPLACE THIS MODULE
 
 You can replace the test scripts using `Test::CheckManifest` with this one
-using [ExtUtils::Manifest](https://metacpan.org/pod/ExtUtils::Manifest).
+using [ExtUtils::Manifest](https://metacpan.org/pod/ExtUtils%3A%3AManifest).
 
     use Test::More tests => 2;
     use ExtUtils::Manifest;

--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -140,9 +140,9 @@ sub _manifest_files {
 
 sub ok_manifest {
     my ($hashref,$msg) = _validate_args( @_ );
-    
+
     $test->plan(tests => 1) if !$plan;
-    
+
     my $home     = _find_home( $hashref );
     my $manifest = File::Spec->catfile( $home, 'MANIFEST' );
 
@@ -155,7 +155,7 @@ sub ok_manifest {
         $test->diag( "No files in MANIFEST found (is it readable?)" );
         return;
     }
-    
+
     my $skip_path  = File::Spec->catfile( $home, 'MANIFEST.SKIP' );
     my @skip_files = _read_file( $skip_path );
     my @skip_rx    = map{ qr/$_/ }@skip_files;
@@ -178,7 +178,7 @@ sub ok_manifest {
                 \@skip_rx,
                 $home,
             );
-            
+
             my $abs = File::Spec->rel2abs($file);
 
             $is_excluded ?
@@ -308,7 +308,11 @@ sub _is_excluded {
     return 0 if $files_in_skip and 'ARRAY' ne ref $files_in_skip;
 
     if ( $files_in_skip ) {
-        (my $local_file = $file) =~ s{\Q$home\E}{};
+
+        # $home is usually given without trailing slash,
+        # the $files_in_skip is taken from MANIFEST.SKIP which usually contain regexes
+        # for files relative the $home. Therefore the remaining leading slashes in $localfile
+        (my $local_file = $file) =~ s{\Q$home\E/*}{};
         for my $rx ( @{$files_in_skip} ) {
             return 1 if $local_file =~ $rx;
         }

--- a/t/02_validate_args.t
+++ b/t/02_validate_args.t
@@ -9,6 +9,7 @@ use Test::CheckManifest;
 
 # create a directory and a file 
 my $sub = Test::CheckManifest->can('_validate_args');
+ok $sub;
 
 my $default = {
     filter  => [],

--- a/t/03_find_home.t
+++ b/t/03_find_home.t
@@ -11,6 +11,7 @@ use Cwd;
 
 # create a directory and a file 
 my $sub = Test::CheckManifest->can('_find_home');
+ok $sub;
 
 my $dir  = Cwd::realpath( File::Spec->catdir( dirname( __FILE__ ), '..' ) );
 my $file = File::Spec->catfile( $dir, 'MANIFEST' );

--- a/t/04_check_excludes.t
+++ b/t/04_check_excludes.t
@@ -11,6 +11,8 @@ use Test::More;
 
 # create a directory and a file 
 my $sub = Test::CheckManifest->can('_check_excludes');
+ok $sub;
+
 my $dir = Cwd::realpath( dirname __FILE__ );
 $dir    =~ s{.t\z}{};
 
@@ -24,6 +26,5 @@ $dir    =~ s{.t\z}{};
 
     is_deeply $sub->( { exclude => undef }, '' ), [ ], 'exclude is undef';
 }
-
 
 done_testing();

--- a/t/05_is_excluded.t
+++ b/t/05_is_excluded.t
@@ -22,6 +22,7 @@ my $t_dir = File::Spec->catdir( $dir, 't' );
 my $meta  = 'META.yml';
 
 my $abs_t_file = File::Spec->rel2abs( __FILE__ );
+my $this_file  = basename($abs_t_file);
 my $bak_t_file = $abs_t_file . '.bak';
 
 # my ($file,$dirref,$filter,$bool,$files_in_skip,$home) = @_;
@@ -127,7 +128,17 @@ my @tests = (
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$abs_t_file\E/] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', excluded",
-    ], 
+    ],
+    [
+        [ $abs_t_file, [], [], undef, [qr/^$this_file/], $t_dir ],
+        1,
+        "this file, matched by files_in_skip with start of string anchor",
+    ],
+    [
+        [ $abs_t_file, [], [], undef, [qr/\/$this_file/], $t_dir ],
+        0,
+        "this file, not matched by files_in_skip because of leading slash",
+    ],
 );
 
 for my $test ( @tests ) {

--- a/t/05_is_excluded.t
+++ b/t/05_is_excluded.t
@@ -101,8 +101,13 @@ my @tests = (
     ],
     [
         [ '/tmp/test', [ $t_dir ], [qr/excluded/], 'and', ['/test'], '/tmp' ],
-        1,
+        0,
         "/tmp/test, t/ dir, filter: 'excluded', bool => 'and', skip /test in /tmp",
+    ],
+    [
+        [ '/tmp/test', [ $t_dir ], [qr/excluded/], 'and', ['^test'], '/tmp' ],
+        1,
+        "/tmp/test, t/ dir, filter: 'excluded', bool => 'and', skip ^test in /tmp",
     ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$bak_t_file\E/] ],

--- a/t/05_is_excluded.t
+++ b/t/05_is_excluded.t
@@ -26,102 +26,103 @@ my $bak_t_file = $abs_t_file . '.bak';
 
 # my ($file,$dirref,$filter,$bool,$files_in_skip,$home) = @_;
 
+# set up testcases
 my @tests = (
     [
-        [ $meta ],
-        1,
-        $meta,
-    ], 
+        [ $meta ],   # arguments
+        1,           # success
+        $meta,       # description
+    ],
     [
         [ $meta, [] ],
         1,
         "meta, empty dirref",
-    ], 
+    ],
     [
         [ $meta, [$t_dir] ],
         1,
         "meta, t/ directory",
-    ], 
+    ],
     [
         [ $abs_t_file ],
         0,
         "this file",
-    ], 
+    ],
     [
         [ $abs_t_file, [] ],
         0,
         "this file, empty dirref",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ] ],
         1,
         "this file, t/ dir",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/] ],
         2,
         "this file, t/ dir, filter: 'excluded'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and' ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/not_excluded/] ],
         1,
         "this file, t/ dir, filter: 'not_excluded'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/not_excluded/], 'and' ],
         0,
         "this file, t/ dir, filter: 'not_excluded', bool => 'and'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', empty files_in_skip",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$abs_t_file\E/] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', skip this file",
-    ], 
+    ],
     [
         [ $abs_t_file . '.bak', [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$bak_t_file\E/] ],
         1,
         "<this_file>.bak, t/ dir, filter: 'excluded', bool => 'and', skip backup of this file",
-    ], 
+    ],
     [
         [ '/tmp/test', [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$bak_t_file\E/] ],
         0,
         "/tmp/test, t/ dir, filter: 'excluded', bool => 'and', skip backup of this file",
-    ], 
+    ],
     [
         [ '/tmp/test', [ $t_dir ], [qr/excluded/], 'and', ['/test'], '/tmp' ],
         1,
         "/tmp/test, t/ dir, filter: 'excluded', bool => 'and', skip /test in /tmp",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$bak_t_file\E/] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', skip backup of this file",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', {} ],
         0,
         "this file, t/ dir, filter: 'excluded', bool => 'and', wrong reftype files_in_skip",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and' ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'or' ],
         2,
         "this file, t/ dir, filter: 'excluded', bool => 'or'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$abs_t_file\E/] ],
         1,

--- a/t/05_is_excluded.t
+++ b/t/05_is_excluded.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+
 use File::Spec;
 use File::Basename;
 use Test::More;
@@ -10,8 +11,9 @@ use Cwd;
 use Test::More;
 use Test::CheckManifest;
 
-# create a directory and a file 
+# create a directory and a file
 my $sub = Test::CheckManifest->can('_is_excluded');
+ok $sub;
 
 my $dir   = Cwd::realpath( dirname __FILE__ );
 $dir      =~ s{.t\z}{};
@@ -132,6 +134,5 @@ for my $test ( @tests ) {
     my $ret = $sub->( @{$input} );
     is $ret, $check, $desc;
 }
-
 
 done_testing();


### PR DESCRIPTION
I wanted to use Test::CheckManifest in one of my projects. In MANIFEST.SKIP I had something like `^ignore_me.txt` and I wondered why the file _ignore_me.txt_ was reported to be missing. As a workaround I also add `/ignore_me.txt` to MANIFEST.SKIP.

The reason seems to be that releative files with a leading slash was compared to the regexes in MANIFEST.SKIP. This matters mostly when only top level files should be ignored.