### PR TITLE
Bump copyright year to match latest release year

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -148,7 +148,7 @@ Renee Baecker <reneeb@cpan.org>
 
 # COPYRIGHT AND LICENSE
 
-This software is Copyright (c) 2018 by Renee Baecker.
+This software is Copyright (c) 2019 by Renee Baecker.
 
 This is free software, licensed under:
 

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Test-CheckManifest
 author  = Renee Baecker <reneeb@cpan.org>
 license = Artistic_2_0
 copyright_holder = Renee Baecker
-copyright_year   = 2018
+copyright_year   = 2019
 
 [Git::Contributors]
 include_authors = 1


### PR DESCRIPTION
Hi Renee!

I noticed that the most recent release was from 2019, but the copyright year in `dzil.ini` was 2018.  This PR brings the metadata up to date to match the current release.

Hope this helps!