### PR TITLE
Purge trailing whitespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -163,7 +163,7 @@ Revision history for Perl extension Test::CheckManifest.
 
 0.6   2006-11-21
         Test scripts improved
-      
+
 0.5   2006-11-18
       - bugfix: T::CM now works under taint mode (http://rt.cpan.org/Public/Bug/Display.html?id=22927)
       + added : ok_manifest accepts hashref where specific dirs can be excluded
@@ -175,7 +175,7 @@ Revision history for Perl extension Test::CheckManifest.
 0.3   2006-10-18
       - bugfix: CheckManifest works under Solaris now
 
-0.2   2006-10-03 
+0.2   2006-10-03
       - bugfix: some files excluded from test
 
 0.1   2006-09-29

--- a/README.mkdn
+++ b/README.mkdn
@@ -51,8 +51,8 @@ These files would be excluded (as examples):
 
 You can also combine "filter" and "exclude" with 'and' or 'or' default is 'or':
 
-    ok_manifest({exclude => ['/var/test'], 
-                 filter  => [qr/\.svn/], 
+    ok_manifest({exclude => ['/var/test'],
+                 filter  => [qr/\.svn/],
                  bool    => 'and'});
 
 These files have to be named in the `MANIFEST`:

--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -39,7 +39,7 @@ sub import {
 
     $test->exported_to($caller);
     $test->plan(%plan);
-    
+
     $plan = 1 if(exists $plan{tests});
 }
 
@@ -66,7 +66,7 @@ sub _validate_args {
 
     my $bool = lc( $hashref->{bool} || '' );
     $hashref->{bool} = $bool && $bool eq 'and' ? 'and' : 'or';
-    
+
     return $hashref, $msg;
 }
 
@@ -88,7 +88,7 @@ sub _check_excludes {
 
         push @excluded, $path;
     }
-    
+
     return \@excluded;
 }
 
@@ -140,9 +140,9 @@ sub _manifest_files {
 
 sub ok_manifest {
     my ($hashref,$msg) = _validate_args( @_ );
-    
+
     $test->plan(tests => 1) if !$plan;
-    
+
     my $home     = _find_home( $hashref );
     my $manifest = File::Spec->catfile( $home, 'MANIFEST' );
 
@@ -155,7 +155,7 @@ sub ok_manifest {
         $test->diag( "No files in MANIFEST found (is it readable?)" );
         return;
     }
-    
+
     my $skip_path  = File::Spec->catfile( $home, 'MANIFEST.SKIP' );
     my @skip_files = _read_file( $skip_path );
     my @skip_rx    = map{ qr/$_/ }@skip_files;
@@ -178,7 +178,7 @@ sub ok_manifest {
                 \@skip_rx,
                 $home,
             );
-            
+
             my $abs = File::Spec->rel2abs($file);
 
             $is_excluded ?
@@ -229,14 +229,14 @@ sub _check_manifest {
     my %seen_files = ();
     @dup_files = map { $seen_files{$_}++ ? $_ : () } @manifest;
     $bool = 0 if scalar @dup_files > 0;
-    
+
     my $diag = 'The following files are not named in the MANIFEST file: '.
                join(', ', sort keys %missing_files);
     my $plus = 'The following files are not part of distro but named in the MANIFEST file: '.
                join(', ',@files_plus);
     my $dup  = 'The following files appeared more than once in the MANIFEST file: '.
                join(', ',@dup_files);
-    
+
     my $success;
 
     if ( !$ENV{NO_MANIFEST_CHECK} ) {
@@ -259,17 +259,17 @@ sub _read_file {
     my ($path) = @_;
 
     return if !-r $path;
-    
+
     my @files;
 
     open my $fh, '<', $path;
     while( my $fh_line = <$fh> ){
         chomp $fh_line;
-        
+
         next if $fh_line =~ m{ \A \s* \# }x;
-        
+
         my ($file);
-        
+
         if ( ($file) = $fh_line =~ /^'(\\[\\']|.+)+'\s*/) {
             $file =~ s/\\([\\'])/$1/g;
         }
@@ -283,7 +283,7 @@ sub _read_file {
     }
 
     close $fh;
-    
+
     chomp @files;
 
     {
@@ -320,7 +320,7 @@ sub _is_excluded {
     return 1 if @matches;
 
     my $is_in_dir = _is_in_dir( $file, $dirref );
-    
+
     $bool ||= 'or';
     if ( $bool eq 'or' ) {
         push @matches, $file if grep{ $file =~ /$_/ }@$filter;
@@ -331,7 +331,7 @@ sub _is_excluded {
             push @matches, $file;
         }
     }
-    
+
     return scalar @matches;
 }
 
@@ -421,8 +421,8 @@ These files would be excluded (as examples):
 
 You can also combine "filter" and "exclude" with 'and' or 'or' default is 'or':
 
-  ok_manifest({exclude => ['/var/test'], 
-               filter  => [qr/\.svn/], 
+  ok_manifest({exclude => ['/var/test'],
+               filter  => [qr/\.svn/],
                bool    => 'and'});
 
 These files have to be named in the C<MANIFEST>:
@@ -466,7 +466,7 @@ using L<ExtUtils::Manifest>.
 
     use Test::More tests => 2;
     use ExtUtils::Manifest;
-    
+
     is_deeply [ ExtUtils::Manifest::manicheck() ], [], 'missing';
     is_deeply [ ExtUtils::Manifest::filecheck() ], [], 'extra';
 

--- a/t/01_selftest.t
+++ b/t/01_selftest.t
@@ -11,7 +11,7 @@ plan skip_all => "Test::CheckManifest required" if $@;
 
 #$Test::CheckManifest::VERBOSE = 0;
 
-# create a directory and a file 
+# create a directory and a file
 my $home = dirname(File::Spec->rel2abs($0));
 
 my $dir   = File::Spec->catdir($home,'.git');

--- a/t/02_validate_args.t
+++ b/t/02_validate_args.t
@@ -7,7 +7,7 @@ use File::Basename;
 use Test::More;
 use Test::CheckManifest;
 
-# create a directory and a file 
+# create a directory and a file
 my $sub = Test::CheckManifest->can('_validate_args');
 
 my $default = {

--- a/t/03_find_home.t
+++ b/t/03_find_home.t
@@ -9,7 +9,7 @@ use File::Path qw(make_path remove_tree);
 use Test::CheckManifest;
 use Cwd;
 
-# create a directory and a file 
+# create a directory and a file
 my $sub = Test::CheckManifest->can('_find_home');
 
 my $dir  = Cwd::realpath( File::Spec->catdir( dirname( __FILE__ ), '..' ) );

--- a/t/04_check_excludes.t
+++ b/t/04_check_excludes.t
@@ -9,7 +9,7 @@ use File::Basename;
 use Test::CheckManifest;
 use Test::More;
 
-# create a directory and a file 
+# create a directory and a file
 my $sub = Test::CheckManifest->can('_check_excludes');
 my $dir = Cwd::realpath( dirname __FILE__ );
 $dir    =~ s{.t\z}{};

--- a/t/05_is_excluded.t
+++ b/t/05_is_excluded.t
@@ -10,7 +10,7 @@ use Cwd;
 use Test::More;
 use Test::CheckManifest;
 
-# create a directory and a file 
+# create a directory and a file
 my $sub = Test::CheckManifest->can('_is_excluded');
 
 my $dir   = Cwd::realpath( dirname __FILE__ );
@@ -29,102 +29,102 @@ my @tests = (
         [ $meta ],
         1,
         $meta,
-    ], 
+    ],
     [
         [ $meta, [] ],
         1,
         "meta, empty dirref",
-    ], 
+    ],
     [
         [ $meta, [$t_dir] ],
         1,
         "meta, t/ directory",
-    ], 
+    ],
     [
         [ $abs_t_file ],
         0,
         "this file",
-    ], 
+    ],
     [
         [ $abs_t_file, [] ],
         0,
         "this file, empty dirref",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ] ],
         1,
         "this file, t/ dir",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/] ],
         2,
         "this file, t/ dir, filter: 'excluded'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and' ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/not_excluded/] ],
         1,
         "this file, t/ dir, filter: 'not_excluded'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/not_excluded/], 'and' ],
         0,
         "this file, t/ dir, filter: 'not_excluded', bool => 'and'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', empty files_in_skip",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$abs_t_file\E/] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', skip this file",
-    ], 
+    ],
     [
         [ $abs_t_file . '.bak', [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$bak_t_file\E/] ],
         1,
         "<this_file>.bak, t/ dir, filter: 'excluded', bool => 'and', skip backup of this file",
-    ], 
+    ],
     [
         [ '/tmp/test', [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$bak_t_file\E/] ],
         0,
         "/tmp/test, t/ dir, filter: 'excluded', bool => 'and', skip backup of this file",
-    ], 
+    ],
     [
         [ '/tmp/test', [ $t_dir ], [qr/excluded/], 'and', ['/test'], '/tmp' ],
         1,
         "/tmp/test, t/ dir, filter: 'excluded', bool => 'and', skip /test in /tmp",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$bak_t_file\E/] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', skip backup of this file",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', {} ],
         0,
         "this file, t/ dir, filter: 'excluded', bool => 'and', wrong reftype files_in_skip",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and' ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'or' ],
         2,
         "this file, t/ dir, filter: 'excluded', bool => 'or'",
-    ], 
+    ],
     [
         [ $abs_t_file, [ $t_dir ], [qr/excluded/], 'and', [qr/\Q$abs_t_file\E/] ],
         1,
         "this file, t/ dir, filter: 'excluded', bool => 'and', excluded",
-    ], 
+    ],
 );
 
 for my $test ( @tests ) {

--- a/t/xt/03_issue7.t
+++ b/t/xt/03_issue7.t
@@ -19,12 +19,12 @@ SKIP: {
         my $fh_manifest = IO::File->new( $dir . '/MANIFEST', 'w' );
         $fh_manifest->print( $_ . "\n" ) for (qw/MANIFEST A.txt B.txt 02_issue1.t 03_issue7.t/);
         $fh_manifest->close or die $!;
-        
+
         # create file
         my $fh = IO::File->new( $dir . '/A.txt', 'w' );
         $fh->print( scalar localtime ) or die $!;
         $fh->close or die $!;
-        
+
         # create symlink
         eval { symlink $dir . '/A.txt', $dir . '/B.txt' };
 


### PR DESCRIPTION
This is a simple change which removes all trailing whitespace from source files. Some projects forbid trailing whitespace (such as the Linux kernel) and others find it to be merely nit-picking.  This change is submitted in the hope that it is useful; I won't be disappointed if you don't merge it :-)  I've split up the PR into separate commits to make reviewing the diffs easier, so if you'd like these changes squashed into a single commit, just let me know and I'll fix up the PR and resubmit.