### PR TITLE
Replace string eval with block eval

### DIFF
--- a/t/01_selftest.t
+++ b/t/01_selftest.t
@@ -6,7 +6,7 @@ use File::Spec;
 use File::Basename;
 use Test::More;
 
-eval "use Test::CheckManifest tests => 10";
+eval { use Test::CheckManifest tests => 10 };
 plan skip_all => "Test::CheckManifest required" if $@;
 
 #$Test::CheckManifest::VERBOSE = 0;

--- a/t/06_bailout.t
+++ b/t/06_bailout.t
@@ -6,7 +6,7 @@ use File::Spec;
 use File::Basename;
 use Test::More;
 
-eval "use Test::CheckManifest tests => 2";
+eval { use Test::CheckManifest tests => 2 };
 plan skip_all => "Test::CheckManifest required" if $@;
 
 $Test::CheckManifest::HOME = '/tmp/' . $$ . '/test';

--- a/t/extra/02_test_in_subdirectory.t
+++ b/t/extra/02_test_in_subdirectory.t
@@ -6,7 +6,7 @@ use File::Spec;
 use File::Basename;
 use Test::More;
 
-eval "use Test::CheckManifest tests => 1";
+eval { use Test::CheckManifest tests => 1 };
 plan skip_all => "Test::CheckManifest required" if $@;
 
 ok_manifest({filter => [qr/\.(?:svn|git|build)/]},'Filter: \.(?:svn|git)');


### PR DESCRIPTION
This is because the string form of `eval` is compiled every time it is executed (and doesn't give compile-time warnings), whereas the block form is only compiled the once.  Thus it is recommended in [Perl::Critic](https://metacpan.org/pod/Perl::Critic::Policy::BuiltinFunctions::ProhibitStringyEval) to avoid "stringy eval".