### PR TITLE
Avoid Perl::Critic warning on "no strict 'refs'"

### DIFF
--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -33,7 +33,7 @@ sub import {
     my %plan   = @_;
 
     for my $func ( qw( ok_manifest ) ) {
-        no strict 'refs';
+        no strict 'refs';  ## no critic
         *{$caller."::".$func} = \&$func;
     }
 


### PR DESCRIPTION
... because this instance of `no strict` is intended in this case, hence it's good to get rid of the unnecessary false positive from `perlcritic`.