### PR TITLE
Test code via GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI Test::CheckManifest
+
+on:
+    push:
+        branches: '*'
+    pull_request:
+        branches: '*'
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - 'latest'
+          - '5.36'
+          - '5.34'
+          - '5.32'
+          - '5.30'
+          - '5.28'
+          - '5.26'
+          - '5.24'
+          - '5.22'
+          - '5.20'
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+    name: Perl ${{ matrix.perl-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Author and release tests
+        run: |
+          dzil authordeps --missing | cpanm --notest
+          dzil listdeps --author --missing | cpanm --notest
+          dzil test --author --release
+
+  non-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-latest, windows-latest]
+        perl-version:
+          - 'latest'
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.runner }}; Perl ${{ matrix.perl-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Windows Perl
+        if: ${{ startsWith( matrix.runner, 'windows-' )  }}
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+          distribution: strawberry
+      - name: Set up MacOS Perl
+        if: ${{ startsWith( matrix.runner, 'macos-' )  }}
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - name: Author and release tests
+        run: |
+          cpanm --notest Dist::Zilla
+          dzil authordeps --missing | cpanm --notest
+          dzil listdeps --author --missing | cpanm --notest
+          dzil test --author --release

--- a/README.mkdn
+++ b/README.mkdn
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/reneeb/Test-CheckManifest.svg?branch=master)](https://travis-ci.org/reneeb/Test-CheckManifest)
+[![Actions Status](https://github.com/reneeb/Test-CheckManifest/workflows/ci.yml/badge.svg)](https://github.com/reneeb/Test-CheckManifest/actions)
 [![Kwalitee status](http://cpants.cpanauthors.org/dist/Test-CheckManifest.png)](http://cpants.charsbar.org/dist/overview/Test-CheckManifest)
 [![GitHub issues](https://img.shields.io/github/issues/reneeb/Test-CheckManifest.svg)](https://github.com/reneeb/Test-CheckManifest/issues)
 

--- a/dist.ini
+++ b/dist.ini
@@ -34,7 +34,7 @@ phase = build
 phase = build
 
 [GitHubREADME::Badge]
-badges = travis
+badges = github_actions/ci.yml
 badges = cpants
 badges = issues
 phase = build


### PR DESCRIPTION
This change adds an initial configuration for GitHub actions so that it's possible to check `Test::CheckManifest` on multiple Perls as well as multiple platforms.  This config will check any pushes to any branch as well as all pull requests.

It turns out that to test multiple Perls, it's easier to do this on Linux and this has a separate configuration to Windows and MacOS because in the Linux case one can use Docker images which means that the instances are set up and running very quickly.

In the case of Windows and MacOS it's necessary to install `Dist::Zilla` which takes some time (even with tests turned off), hence it doesn't make any sense to check multiple Perls on these systems because it'd take too long (and I'm not sure if so many Perls are available on those systems anyway).

Even though the syntax of this module is compatible with Perl 5.6 and upwards, it's only possible to test 5.20 and upwards as these are the only docker images available which have `Dist::Zilla` pre-installed.