### PR TITLE
Set minimum Perl version explicitly

### DIFF
--- a/lib/Test/CheckManifest.pm
+++ b/lib/Test/CheckManifest.pm
@@ -4,6 +4,7 @@ package Test::CheckManifest;
 
 use strict;
 use warnings;
+use 5.008;
 
 use Cwd;
 use Carp;


### PR DESCRIPTION
`Perl::MinimumVersion` showed that no explicit minimum Perl version was mentioned in the source code.  The version that `Perl::Minimum` version automatically detected was 5.006, however I noticed that the minimum Perl version mentioned in the `dist.ini` is 5.008, hence I've also set the minimum version within the main module to this (slightly higher) version.