### PR TITLE
Fix GitHub actions badge URL in README

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,4 +1,4 @@
-[![Actions Status](https://github.com/reneeb/Test-CheckManifest/workflows/ci.yml/badge.svg)](https://github.com/reneeb/Test-CheckManifest/actions)
+[![Actions Status](https://github.com/reneeb/Test-CheckManifest/actions/workflows/ci.yml/badge.svg)](https://github.com/reneeb/Test-CheckManifest/actions)
 [![Kwalitee status](https://cpants.cpanauthors.org/dist/Test-CheckManifest.png)](https://cpants.cpanauthors.org/dist/Test-CheckManifest)
 [![GitHub issues](https://img.shields.io/github/issues/reneeb/Test-CheckManifest.svg)](https://github.com/reneeb/Test-CheckManifest/issues)
 


### PR DESCRIPTION
It seems that I was using an outdated
`Dist::Zilla::Plugin::GitHubREADME::Badge` when I submitted the original patch to add the GitHub actions badge.  This patch fixes that error.